### PR TITLE
Don't emit values if output port is disconnected

### DIFF
--- a/lib/MathComponent.coffee
+++ b/lib/MathComponent.coffee
@@ -19,10 +19,12 @@ class MathComponent extends noflo.Component
     calculate = =>
       for group in @primary.group
         @outPorts[res].beginGroup group
-      @outPorts[res].send @calculate @primary.value, @secondary
+      if @outPorts[res].isAttached()
+        @outPorts[res].send @calculate @primary.value, @secondary
       for group in @primary.group
         @outPorts[res].endGroup()
-      @outPorts[res].disconnect() if @primary.disconnect
+      if @outPorts[res].isConnected() and @primary.disconnect
+        @outPorts[res].disconnect()
 
     @inPorts[primary].on 'begingroup', (group) =>
       @groups.push group


### PR DESCRIPTION
While playing with math components on a running graph, I get error notifications in the UI because the math components try to send values on ports not yet connected.
Just a simple patch to avoid those warnings.
