### PR TITLE
Make coffeescript command line compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "prebuild": "noflo-cache-preheat",
     "build": "webpack --config node_modules/noflo-webpack-config/webpack.config.js",
-    "pretest": "coffeelint -f coffeelint.json components/*.coffee && coffee -b -c spec/*.coffee",
+    "pretest": "coffeelint -f coffeelint.json -r components && coffee -b -c spec",
     "test:node": "mocha --exit --require node_modules/noflo-webpack-config/inject.js spec/*.js",
     "test:browser": "karma start node_modules/noflo-webpack-config/karma.config.js",
     "test": "npm run test:node && npm run test:browser"


### PR DESCRIPTION
The coffeescript command line in package.json fails on Windows (see below).  This PR addresses the path issue.


cwill@DESKTOP-HQKC4C2 MINGW64 /c/git/EncantoPOC/noflo-math (master)
$ npm test

> noflo-math@0.3.1 pretest C:\git\EncantoPOC\noflo-math
> coffeelint -f coffeelint.json components/*.coffee && coffee -b -c spec/*.coffee

internal/fs/utils.js:269
    throw err;
    ^

Error: ENOENT: no such file or directory, stat 'components/*.coffee'
    at Object.statSync (fs.js:1016:3)
    at findCoffeeScripts (C:\git\EncantoPOC\noflo-math\node_modules\coffeelint\lib\commandline.js:85:14)
    at Object.<anonymous> (C:\git\EncantoPOC\noflo-math\node_modules\coffeelint\lib\commandline.js:269:17)
    at Object.<anonymous> (C:\git\EncantoPOC\noflo-math\node_modules\coffeelint\lib\commandline.js:279:4)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Module.require (internal/modules/cjs/loader.js:1025:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (C:\git\EncantoPOC\noflo-math\node_modules\coffeelint\bin\coffeelint:34:5)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
 {
  errno: -4058,
  syscall: 'stat',
  code: 'ENOENT',
  path: 'components/*.coffee'
}
npm ERR! Test failed.  See above for more details.
